### PR TITLE
PyTorch refactor

### DIFF
--- a/pyqrack/qrack_neuron.py
+++ b/pyqrack/qrack_neuron.py
@@ -51,13 +51,14 @@ class QrackNeuron:
         activation_fn=NeuronActivationFn.Sigmoid,
         alpha=1.0,
         _init=True,
+        _isTorch=False
     ):
         self.simulator = simulator
         self.controls = controls
         self.target = target
         self.activation_fn = activation_fn
         self.alpha = alpha
-        self.angles = QrackNeuron._real1_byref([0.0] * (1 << len(controls)))
+        self.angles = None if _isTorch else QrackNeuron._real1_byref([0.0] * (1 << len(controls)))
 
         if not _init:
             return

--- a/pyqrack/qrack_neuron_torch_layer.py
+++ b/pyqrack/qrack_neuron_torch_layer.py
@@ -39,44 +39,46 @@ class QrackNeuronTorchFunction(Function if _IS_TORCH_AVAILABLE else object):
     """Static forward/backward/apply functions for QrackNeuronTorch"""
 
     @staticmethod
+    def _apply(angles, neuron):
+        # Baseline probability BEFORE applying this neuron's unitary
+        pre_prob = neuron.simulator.prob(neuron.target)
+
+        neuron.angles = angles.ctypes.data_as(ctypes.POINTER(fp_type))
+
+        # Probability AFTER applying this neuron's unitary
+        post_prob = neuron.predict(True, False)
+
+        # Angle difference
+        delta = math.asin(post_prob) - math.asin(pre_prob)
+
+        # Return shape: (1,)
+        return delta, post_prob
+
+    @staticmethod
     def forward(ctx, x, neuron):
         ctx.neuron = neuron
         ctx.simulator = neuron.simulator
         ctx.save_for_backward(x)
 
-        # Baseline probability BEFORE applying this neuron's unitary
-        pre_prob = neuron.simulator.prob(neuron.target)
-
         angles = x.detach().cpu().numpy() if x.requires_grad else x.numpy()
-        neuron.angles = angles.ctypes.data_as(ctypes.POINTER(fp_type))
+        delta, post_prob = QrackNeuronTorchFunction._apply(angles, neuron)
 
-        # Probability AFTER applying this neuron's unitary
-        post_prob = neuron.predict(True, False)
         ctx.post_prob = post_prob
-
-        delta = math.asin(post_prob) - math.asin(pre_prob)
         ctx.delta = delta
 
-        # Return shape: (1,)
         return x.new_tensor([delta])
 
     @staticmethod
-    def backward(ctx, grad_output):
-        (x,) = ctx.saved_tensors
-        neuron = ctx.neuron
-        neuron.set_simulator(ctx.simulator)
-        post_prob = ctx.post_prob
-
-        angles = x.detach().cpu().numpy() if x.requires_grad else x.numpy()
-
+    def _backward(angles, neuron, simulator, post_prob):
         # Restore simulator to state BEFORE this neuron's unitary
+        neuron.set_simulator(simulator)
         neuron.angles = angles.ctypes.data_as(ctypes.POINTER(fp_type))
         neuron.unpredict()
         pre_sim = neuron.simulator
 
-        grad_x = torch.zeros_like(x)
+        grad_x = [0.0] * angles.shape[0]
 
-        for i in range(x.shape[0]):
+        for i in range(angles.shape[0]):
             angle = angles[i]
 
             # θ + π/2
@@ -98,6 +100,19 @@ class QrackNeuronTorchFunction(Function if _IS_TORCH_AVAILABLE else object):
 
         # Restore simulator
         neuron.set_simulator(pre_sim)
+
+        return grad_x
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (x,) = ctx.saved_tensors
+        neuron = ctx.neuron
+        simulator = ctx.simulator
+        post_prob = ctx.post_prob
+
+        angles = x.detach().cpu().numpy() if x.requires_grad else x.numpy()
+
+        grad_x = torch.tensor(QrackNeuronTorchFunction._backward(angles, neuron, simulator, post_prob), device=x.device, dtype=x.dtype)
 
         # Apply chain rule and upstream gradient
         grad_x *= grad_output[0] / math.sqrt(max(1.0 - post_prob * post_prob, 1e-6))

--- a/pyqrack/qrack_neuron_torch_layer.py
+++ b/pyqrack/qrack_neuron_torch_layer.py
@@ -64,7 +64,6 @@ class QrackNeuronTorchFunction(Function if _IS_TORCH_AVAILABLE else object):
         delta, denom = QrackNeuronTorchFunction._apply(angles, neuron)
 
         ctx.denom = denom
-        ctx.delta = delta
 
         return x.new_tensor([delta])
 

--- a/pyqrack/qrack_neuron_torch_layer.py
+++ b/pyqrack/qrack_neuron_torch_layer.py
@@ -215,7 +215,7 @@ class QrackNeuronTorchLayer(nn.Module if _IS_TORCH_AVAILABLE else object):
                     )
                     neurons.append(
                         QrackNeuronTorch(
-                            QrackNeuron(self.simulator, input_subset, output_id, activation), angles
+                            QrackNeuron(self.simulator, input_subset, output_id, activation, _isTorch=True), angles
                         )
                     )
                     param_count += p_count


### PR DESCRIPTION
The original intent here was to parallelize over batch rows, but, upon getting this far, I realize that likely wouldn't make practical sense, given `QrackSimulator` parallelism and the dependence of `QrackNeuronTorch` weight gradient on input `RY`-angles. However, for the sake of gradient calculation efficiency and separation of concerns, we break `QrackNeuronTorch` logic up into _numerical-only_ sections and `torch` wrapper functions. This inserts a lot less "noise" into the gradient-calculation graph, for back propagation.